### PR TITLE
Include logback.xml resource in native image

### DIFF
--- a/src/main/resources/META-INF/native-image/co.innerproduct/ping/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/co.innerproduct/ping/reflect-config.json
@@ -162,5 +162,19 @@
     {
         "name": "ch.qos.logback.classic.pattern.LineSeparatorConverter",
         "allDeclaredConstructors": true
+    },
+    {
+        "name": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+        "allPublicMethods":true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "name": "ch.qos.logback.core.ConsoleAppender",
+        "allPublicMethods":true,
+        "allDeclaredConstructors": true
+    },
+    {
+        "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+        "allDeclaredConstructors": true
     }
 ]

--- a/src/main/resources/META-INF/native-image/co.innerproduct/ping/resource-config.json
+++ b/src/main/resources/META-INF/native-image/co.innerproduct/ping/resource-config.json
@@ -1,0 +1,5 @@
+{
+  "resources":[
+    {"pattern":"logback.xml"}
+  ]
+}


### PR DESCRIPTION
Native image built with provided configuration is missing `logback.xml` file and therefore the app is using some default configuration (no colors, debug level). Based on the simplest usage of https://github.com/oracle/graal/blob/master/substratevm/CONFIGURE.md#assisted-configuration-of-native-image-builds I've discovered missing `resource-config.json` file and a few logback classes in `reflect-config.json` as well. 
`com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl` is most likely needed to parse `logback.xml` file and it was reported on application startup after building native image.
Thanks for your solution, it was really helpful!